### PR TITLE
Add uuid_to_ulid method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,9 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 sqlite-loadable = "0.0.5"
-ulid = "1.0.0"
+ulid = { version = "1.0.0", features = ["uuid"] }
 chrono = "0.4.23"
+uuid = "1.4.1"
 
 [lib]
 crate-type=["lib", "staticlib", "cdylib"]

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ If your company or organization finds this library useful, consider [supporting 
 select ulid(); -- '01gqr4j69cc7w1xdbarkcbpq17'
 select ulid_bytes(); -- X'0185310899dd7662b8f1e5adf9a5e7c0'
 select ulid_with_prefix('invoice'); -- 'invoice_01gqr4jmhxhc92x1kqkpxb8j16'
-select ulid_with_datetime('2023-01-26 22:53:20.556); -- '01gqr4j69cc7w1xdbarkcbpq17'
+select ulid_with_datetime('2023-01-26 22:53:20.556'); -- '01gqr4j69cc7w1xdbarkcbpq17'
 select ulid_datetime('01gqr4j69cc7w1xdbarkcbpq17') -- '2023-01-26 22:53:20.556'
+select uuid_to_ulid('9421eb94-a98d-431e-b297-d02df7341b8d'); -- '4M47NS9ACD8CFB55YG5QVK86WD'
 ```
 
 Use as a `PRIMARY KEY` for a table.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ If your company or organization finds this library useful, consider [supporting 
 select ulid(); -- '01gqr4j69cc7w1xdbarkcbpq17'
 select ulid_bytes(); -- X'0185310899dd7662b8f1e5adf9a5e7c0'
 select ulid_with_prefix('invoice'); -- 'invoice_01gqr4jmhxhc92x1kqkpxb8j16'
+select ulid_with_datetime('2023-01-26 22:53:20.556); -- '01gqr4j69cc7w1xdbarkcbpq17'
 select ulid_datetime('01gqr4j69cc7w1xdbarkcbpq17') -- '2023-01-26 22:53:20.556'
 ```
 

--- a/docs.md
+++ b/docs.md
@@ -68,6 +68,16 @@ Generates a new ULID string based on the `datetime`. This can be helpful for giv
 select ulid_datetime('2023-01-20 20:00:00.400'); -- '01GQ8C8FWG0W1B5H3W5304049S'
 ```
 
+<h3 name="uuid_to_ulid"><code>uuid_to_ulid(id)</code></h3>
+
+Converts an `Uuid` string to an `Ulid` string. This can be helpful for those who want to convert Uuid columns to Ulid.
+Note: This is tested to work only for UUID v4. It is not guaranteed to work against other UUID versions. Tests are required
+for other versions than v4.
+
+```sql
+select uuid_to_ulid('9421eb94-a98d-431e-b297-d02df7341b8d'); -- '4M47NS9ACD8CFB55YG5QVK86WD'
+```
+
 <h3 name="ulid_datetime"><code>ulid_datetime(ulid)</code></h3>
 
 Extract the timestamp component from the given ULID. The `ulid` parameter can be a string from the [`ulid()`](#ulid) function, a string from the [`ulid_with_prefix()`](#ulid_with_prefix) function, or a blob from the [`ulid_bytes`](#ulid_bytes) function. Returns a text timestamp with `YYYY-MM-DD HH:MM:SS.SSS` format, which can be used with the builtin [`datetime()`](https://www.sqlite.org/lang_datefunc.html) function.

--- a/docs.md
+++ b/docs.md
@@ -60,6 +60,14 @@ select ulid_with_prefix('cus'); -- 'cus_01gqre97xwey5jd694tkg3ncg9'
 select ulid_with_prefix('card'); -- 'card_01gqre9c6az7835tdk00wc0gfp'
 ```
 
+<h3 name="ulid_with_datetime"><code>ulid_with_datetime(datetime)</code></h3>
+
+Generates a new ULID string based on the `datetime`. This can be helpful for giving ULIDs to elements that already have a created time property. The input `datetime` should be in the `YYYY-MM-DD HH:MM:SS.SSS` format.
+
+```sql
+select ulid_datetime('2023-01-20 20:00:00.400'); -- '01GQ8C8FWG0W1B5H3W5304049S'
+```
+
 <h3 name="ulid_datetime"><code>ulid_datetime(ulid)</code></h3>
 
 Extract the timestamp component from the given ULID. The `ulid` parameter can be a string from the [`ulid()`](#ulid) function, a string from the [`ulid_with_prefix()`](#ulid_with_prefix) function, or a blob from the [`ulid_bytes`](#ulid_bytes) function. Returns a text timestamp with `YYYY-MM-DD HH:MM:SS.SSS` format, which can be used with the builtin [`datetime()`](https://www.sqlite.org/lang_datefunc.html) function.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,8 @@ pub fn ulid_datetime(context: *mut sqlite3_context, values: &[*mut sqlite3_value
 
 // TODO ulid_datetime() to ulid_extract_datetime(), ulid_extract_random()
 
-// Convert Uuid to Ulid.
+// Converts Uuids strings to Ulids strings.
+// uuid_to_ulid('9421eb94-a98d-431e-b297-d02df7341b8d') -> '4M47NS9ACD8CFB55YG5QVK86WD'
 pub fn uuid_to_ulid(context: *mut sqlite3_context, values: &[*mut sqlite3_value]) -> Result<()> {
     let input = values.get(0).expect("1st argument required");
     let ulid = match api::value_type(input) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,9 +178,9 @@ pub fn uuid_to_ulid(context: *mut sqlite3_context, values: &[*mut sqlite3_value]
         ValueType::Blob => Ulid(u128::from_be_bytes(
             api::value_blob(input)
                 .try_into()
-                .map_err(|_| Error::new_message("invalid BLOB input to ulid_datetime()"))?,
+                .map_err(|_| Error::new_message("invalid BLOB input to uuid_to_ulid()"))?,
         )),
-        _ => return Err(Error::new_message("unsupported input for ulid_datetime")),
+        _ => return Err(Error::new_message("unsupported input for uuid_to_ulid")),
     };
 
     api::result_text(context, ulid.to_string())?;

--- a/test.sql
+++ b/test.sql
@@ -9,6 +9,8 @@ select ulid(), null as '           ulid_bytes()            ', ulid_with_prefix("
 
 select ulid_datetime('01GMP2G8ZG6PMKWYVKS62TTA41');
 
+-- version 4
+select uuid_to_ulid('9421eb94-a98d-431e-b297-d02df7341b8d');
 
 create table events(
   id text primary key,

--- a/tests/test-loadable.py
+++ b/tests/test-loadable.py
@@ -45,7 +45,7 @@ FUNCTIONS = [
   'ulid_version',
   'ulid_with_datetime',
   'ulid_with_prefix',
-  
+  'uuid_to_ulid'
   
 ]
 
@@ -103,12 +103,15 @@ class TestUlid(unittest.TestCase):
     self.assertEqual(ulid_datetime('u_01gqqt6dz6p00680vw747t8vs5'), '2023-01-26 19:52:09.446')
     #self.assertEqual(ulid_datetime(b'0185d0c5362761312e0483e4c9e3ec5d'), 1671483106288)
     self.assertEqual(ulid_datetime(b'\x01\x85\xe5\xb1\xc5\xe9\xfb\xa7\xf5\xcfSJ\x13\xe4.\xa3'), '2023-01-24 21:31:51.145')
-  
-  
+
+  def test_uuid_to_ulid(self):
+    uuid_to_ulid = lambda uuid: db.execute("select uuid_to_ulid(?)", [uuid]).fetchone()[0]
+    # Version 4
+    self.assertEqual(uuid_to_ulid('9421eb94-a98d-431e-b297-d02df7341b8d'), '4M47NS9ACD8CFB55YG5QVK86WD')
 
 class TestCoverage(unittest.TestCase):                                      
   def test_coverage(self):                                                      
-    test_methods = [method for method in dir(TestUlid) if method.startswith('test_ulid')]
+    test_methods = [method for method in dir(TestUlid) if method.startswith('test_')]
     funcs_with_tests = set([x.replace("test_", "") for x in test_methods])
     for func in FUNCTIONS:
       self.assertTrue(func in funcs_with_tests, f"{func} does not have cooresponding test in {funcs_with_tests}")

--- a/tests/test-loadable.py
+++ b/tests/test-loadable.py
@@ -43,6 +43,7 @@ FUNCTIONS = [
   'ulid_datetime',
   'ulid_debug',
   'ulid_version',
+  'ulid_with_datetime',
   'ulid_with_prefix',
   
   
@@ -88,7 +89,14 @@ class TestUlid(unittest.TestCase):
   def test_ulid_with_prefix(self):
     ulid_with_prefix = lambda prefix: db.execute("select ulid_with_prefix(?)", [prefix]).fetchone()[0]
     self.assertEqual(len(ulid_with_prefix("abc")), 26+4)
-  
+
+  def test_ulid_with_datetime(self):
+    ulid_with_datetime = lambda datetime: db.execute("select ulid_with_datetime(?)", [datetime]).fetchone()[0]
+    ulid_datetime = lambda ulid: db.execute("select ulid_datetime(?)", [ulid]).fetchone()[0]
+
+    ulid = ulid_with_datetime("2023-01-26 19:50:09.428")
+    self.assertEqual(ulid_datetime(ulid), '2023-01-26 19:50:09.428')
+
   def test_ulid_datetime(self):
     ulid_datetime = lambda ulid: db.execute("select ulid_datetime(?)", [ulid]).fetchone()[0]
     self.assertEqual(ulid_datetime('01GMP2G8ZG6PMKWYVKS62TTA41'), '2022-12-19 20:51:46.288')


### PR DESCRIPTION
Added `uuid_to_ulid` method. It's currently tested only for UUID v4. It's also based on this PR: https://github.com/asg017/sqlite-ulid/pull/4. 